### PR TITLE
Switch data.table to Imports:

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,8 +20,7 @@ License: GPL (>= 3)
 Encoding: UTF-8
 LazyData: true
 Depends: 
-    R (>= 2.10),
-    data.table
+    R (>= 2.10)
 RoxygenNote: 7.3.1
 Suggests: 
     testthat (>= 3.0.0),
@@ -29,6 +28,7 @@ Suggests:
     comorbidity (>= 1.0.7)
 Config/testthat/edition: 3
 Imports: 
+    data.table,
     future,
     future.apply,
     cli (>= 3.6.1)

--- a/tests/testthat/test-calc_llr.R
+++ b/tests/testthat/test-calc_llr.R
@@ -1,7 +1,7 @@
 test_that("LLR is close to 0 if q0 = p",{
   expect_equal({
 
-    calc_llr(data.table(cut = "AA1", n0 = 230, n1 = 23),
+    calc_llr(data.table::data.table(cut = "AA1", n0 = 230, n1 = 23),
              no_iteration = 1, p = 0.1)[["llr"]]
 
   }, 0)


### PR DESCRIPTION
Depends are discouraged for data.table:

https://github.com/Rdatatable/data.table/issues/3076

(in fact, we hope that R will eventually deprecate this mode of dependency)

Since you already use import(data.table) in your NAMESPACE, the change is trivial -- we only need to update usages in examples, vignettes and tests that use data.table calls unqualified.

I used {lintr} to find all {data.table} usages in your package

```r
dt_exports <- getNamespaceExports("data.table")
dt_functions <- grep("^[a-zA-Z]", dt_exports, value=TRUE)
dt_operators <- grep("^[%]", dt_exports, value=TRUE)
lintr::lint_package(linters = list(
  lintr::undesirable_function_linter(setNames(nm = dt_functions)),
  lintr::undesirable_operator_linter(setNames(nm = dt_operators))
))
```